### PR TITLE
Added the option to use "configbits", see details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nuimo.js - A Node.js library for interacting with Nuimo devices
 
 UPDATE 0.3.0 - Added options for "setLEDMatrix".
+
 UPDATE 0.2.0 - Adds new features, including:
 
 * RSSI value
@@ -87,14 +88,16 @@ Options are optional values/configurations to be used when setting LED matrices.
 - 6th bit (decimal 32, binair 0b00100000) is "builtin matrices" which gives the possibility to display the builtin led matrices (first byte of the matrix is to indicate which builtin matrix should be displayed). Currently these are not documented and may be subject to changes (can only be changed by Nuimo firmware).
 
 usage:
-setLEDMatrix(yourmatrix, yourbrightness, yourtimeout); //Default behaviour (no options enabled).
-setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, {onion_skinning: true, builtin_matrix: true}); //Enable onion skinning and builtin matrix.
-setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, Nuimo.Options.ONION_SKINNING + Nuimo.Options.BUILTIN_MATRIX); //Enable onion skinning and builtin matrix.
+- setLEDMatrix(yourmatrix, yourbrightness, yourtimeout); //Default behaviour (no options enabled).
+- setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, {onion_skinning: true, builtin_matrix: true}); //Enable onion skinning and builtin matrix.
+- setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, Nuimo.Options.ONION_SKINNING + Nuimo.Options.BUILTIN_MATRIX); //Enable onion skinning and builtin matrix.
 
 or you can define options yourself using a bit field (or by adding bits/bitfields), also see device.js and official Nuimo documentation:
-setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00110000); 
-setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00010000 + 0b00100000);
+- setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00110000); 
+- setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00010000 + 0b00100000);
+
 (You can also choose to use decimal representation of the values, instead of binary)
+
 (This feature is built in, to forward support new bitfield configurations)
 
 #### Events

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Nuimo.js - A Node.js library for interacting with Nuimo devices
 
+UPDATE 0.3.0 - Added options for "setLEDMatrix".
 UPDATE 0.2.0 - Adds new features, including:
 
 * RSSI value
@@ -71,7 +72,7 @@ Received Signal Strength Indicator (RSSI) value of the device.
 
 Connects to a previously discovered Nuimo device. The callback is triggered when the device is ready for interacting with.
 
-##### setLEDMatrix(matrix, brightness, timeout, configbits)
+##### setLEDMatrix(matrix, brightness, timeout, options)
 
 Outputs a pattern to the 9x9 LED matrix on the front of the device.
 
@@ -81,11 +82,20 @@ Matrix is either:
 
 Brightness is a value between 0-255. Timeout is how long the pattern should appear for (In milliseconds).
 
-Configbits is an optional value. It represents bits to toggle specific behaviour.
-Currently only the fifth bit (000X 0000)(decimal 16) is used.
-By passing decimal 16 as the configbits parameter, "Onion Skinning" is enabled, this allows smoother transactions between matrices.
-Not passing the parameter, or passing 0 will cause the default behaviour.
-In future, more options may be added. Please avoid writing to the first bit, since it's the last LED of the matrix.
+Options are optional values/configurations to be used when setting LED matrices.
+- 5th bit (decimal 16, binair 0b00010000) is "onion skinning" which allows smoother transitions between matrices.
+- 6th bit (decimal 32, binair 0b00100000) is "builtin matrices" which gives the possibility to display the builtin led matrices (first byte of the matrix is to indicate which builtin matrix should be displayed). Currently these are not documented and may be subject to changes (can only be changed by Nuimo firmware).
+
+usage:
+setLEDMatrix(yourmatrix, yourbrightness, yourtimeout); //Default behaviour (no options enabled).
+setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, {onion_skinning: true, builtin_matrix: true}); //Enable onion skinning and builtin matrix.
+setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, Nuimo.Options.ONION_SKINNING + Nuimo.Options.BUILTIN_MATRIX); //Enable onion skinning and builtin matrix.
+
+or you can define options yourself using a bit field (or by adding bits/bitfields), also see device.js and official Nuimo documentation:
+setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00110000); 
+setLEDMatrix(yourmatrix, yourbrightness, yourtimeout, 0b00010000 + 0b00100000);
+(You can also choose to use decimal representation of the values, instead of binary)
+(This feature is built in, to forward support new bitfield configurations)
 
 #### Events
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Received Signal Strength Indicator (RSSI) value of the device.
 
 Connects to a previously discovered Nuimo device. The callback is triggered when the device is ready for interacting with.
 
-##### setLEDMatrix(matrix, brightness, timeout)
+##### setLEDMatrix(matrix, brightness, timeout, configbits)
 
 Outputs a pattern to the 9x9 LED matrix on the front of the device.
 
@@ -80,6 +80,12 @@ Matrix is either:
 - A buffer of 11 bytes, each bit representing one of the 81 LED's, with the last 7 of the 11th byte being unused.
 
 Brightness is a value between 0-255. Timeout is how long the pattern should appear for (In milliseconds).
+
+Configbits is an optional value. It represents bits to toggle specific behaviour.
+Currently only the fifth bit (000X 0000)(decimal 16) is used.
+By passing decimal 16 as the configbits parameter, "Onion Skinning" is enabled, this allows smoother transactions between matrices.
+Not passing the parameter, or passing 0 will cause the default behaviour.
+In future, more options may be added. Please avoid writing to the first bit, since it's the last LED of the matrix.
 
 #### Events
 

--- a/nuimo.js
+++ b/nuimo.js
@@ -39,6 +39,10 @@ class Nuimo extends EventEmitter {
     static get Area () {
         return Device.Area;
     }
+    
+    static get Options(){
+        return Device.Options;
+    }
 
     scan () {
         wantScan = true;

--- a/src/device.js
+++ b/src/device.js
@@ -232,7 +232,7 @@ class Device extends EventEmitter {
     }
 
 
-    setLEDMatrix (matrixData, brightness, timeout, configbits) {
+    setLEDMatrix (matrixData, brightness, timeout, options) {
 
         if (this._LEDCharacteristic) {
             let buf = Buffer.alloc(13);
@@ -244,8 +244,8 @@ class Device extends EventEmitter {
             }
             
             //Config bits are optional.
-            if(typeof configbits === "number"){//Senic explained that they use config bits
-                buf[10] += configbits;//These are encoded in the unused bits of the buffer
+            if(typeof options === "number"){//Senic explained that they use config bits
+                buf[10] += options;//These are encoded in the unused bits of the buffer
             }
             if(typeof options === "object"){
                 if(options.onion_skinning == true){

--- a/src/device.js
+++ b/src/device.js
@@ -249,10 +249,10 @@ class Device extends EventEmitter {
             }
             if(typeof options === "object"){
                 if(options.onion_skinning == true){
-                    buf[10] += 0b00010000;
+                    buf[10] += Options.ONION_SKINNING;
                 }
                 if(options.builtin_matrix == true){
-                    buf[10] += 0b00100000;
+                    buf[10] += Options.BUILTIN_MATRIX;
                 }
             }
             //Using configbit = 16 (fifth bit is set, 0b00010000) will enable "Onion Skinning" effect in fading.

--- a/src/device.js
+++ b/src/device.js
@@ -29,6 +29,17 @@ const Area = {
     BOTTOM: 7
 };
 
+//Configuration bits, see https://github.com/nathankunicki/nuimojs/pull/12
+const Options = {
+    //1, 1st (Binair 0b00000001) is used for the matrix.
+    //2, 2nd bit (Binair 0b00000010) not used yet.
+    //4, 3rd bit (Binair 0b00000100) not used yet.
+    //8, 4th bit (Binair 0b00001000) not used yet.
+    ONION_SKINNING: 16,//5th bit, Binair: 0b00010000 used for onion skinning effect (smooth transition between matrices, https://en.wikipedia.org/wiki/Onion_skinning)
+    BUILTIN_MATRIX: 32 //6th bit, Binair: 0b00100000 used for displaying builtin matrices, when enabled, the first byte of the matrix indicates which builtin matrix is displayed. (Currently not documented which builtin matrixes are avaialable)
+    //64, 7th bit (Binair 0b01000000) not used yet.
+    //128,8th bit (Binair 0b10000000) not used yet.
+};
 
 const UUID = {
     Service: {
@@ -80,7 +91,10 @@ class Device extends EventEmitter {
     static get Area () {
         return Area;
     }
-
+    
+    static get Options(){
+        return Options;
+    }
 
     get uuid () {
         return this._peripheral.uuid;
@@ -232,6 +246,14 @@ class Device extends EventEmitter {
             //Config bits are optional.
             if(typeof configbits === "number"){//Senic explained that they use config bits
                 buf[10] += configbits;//These are encoded in the unused bits of the buffer
+            }
+            if(typeof options === "object"){
+                if(options.onion_skinning == true){
+                    buf[10] += 0b00010000;
+                }
+                if(options.builtin_matrix == true){
+                    buf[10] += 0b00100000;
+                }
             }
             //Using configbit = 16 (fifth bit is set, 0b00010000) will enable "Onion Skinning" effect in fading.
             //Other config bits aren't yet used or defined.

--- a/src/device.js
+++ b/src/device.js
@@ -218,7 +218,7 @@ class Device extends EventEmitter {
     }
 
 
-    setLEDMatrix (matrixData, brightness, timeout) {
+    setLEDMatrix (matrixData, brightness, timeout, configbits) {
 
         if (this._LEDCharacteristic) {
             let buf = Buffer.alloc(13);
@@ -228,6 +228,13 @@ class Device extends EventEmitter {
             } else {
                 this._LEDArrayToBuffer(matrixData).copy(buf);
             }
+            
+            //Config bits are optional.
+            if(typeof configbits === "number"){//Senic explained that they use config bits
+                buf[10] += configbits;//These are encoded in the unused bits of the buffer
+            }
+            //Using configbit = 16 (fifth bit is set, 0b00010000) will enable "Onion Skinning" effect in fading.
+            //Other config bits aren't yet used or defined.
 
             buf[11] = brightness;
             buf[12] = Math.floor(timeout / 100);


### PR DESCRIPTION
Many thanks for the awesome library and your contribution on my issue (RSSI), it is of great help to our project (I didn't really know a nice way to implement that myself).
However, I've had another issue, which I was able to resolve myself, and would like to merge it into your project (to have one great repository and not multiple forks with different features).

When sending multiple images after each other, the matrix "resets".
I've asked Senic on how to fix this and they told me they used the last 7 bits of the buffer as "configbits" (see below).

Currently they only have "Onion Skinning" as a possibility, but my code allows any option.
Though, it may to be as user friendly, but it's simple and does the job.

To Senic:

> When displaying a "bar" or "numbers" that you can change by turning, the "fade-in" effect makes it very hard to see the changes. Because every step isn't at 100% brightness immediately, it's hard to scroll through all the steps. (and it looks like a new bar every time, instead of one bar that can be adjusted.
> 
> Can the fade-in effect be disabled?
> 
> I'm using the NuimoJS library by NathanKunicki but I don't believe the fade-in effect (or swiping) has anything to do with the NuimoJS library.
> Does the xcode-swift project allow fade-in to be disabled?
> (I'm using NuimoJS for portability/simplicity reasons)

From Senic:

> Our official SDKs takes care of so called Onion-Skinning Effect. I can explain how it is enabled/disabled. Nuimo has 9x9 LED Matrix that contains 81 LEDs. We need 81 bits to bitmap the whole LED Matrix. Additionally a byte to set the brightness and a byte to set display duration. Therefore totally 13 bytes must be sent to LED characteristics. First 11 bytes represents the bitmap. 11 x 8 bits => 88 bits. In that only 81 bits are used for LEDs and the rest 7 bits are used for other configurations such as enabling Oninon-Skinning effect.  In 11th byte [000X 0001], 5th bit (X) is OnionSkin Bit. So if you don't want to have that effect, then you should keep all the last 7 bits zero.

I'm not sure if we should make a new version out of it, or if we can slide it into the 0.2.0, or put it in a later 0.3.0, but that's up to you I think.

If you need any details, please ask.
