### PR TITLE
Corrected use of "data" event

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -287,7 +287,7 @@ class Device extends EventEmitter {
     }
 
     _subscribeToCharacteristic (characteristic, callback) {
-        characteristic.on("read", (data, isNotification) => {
+        characteristic.on("data", (data, isNotification) => {
             return callback(data);
         });
         characteristic.subscribe((err) => {


### PR DESCRIPTION
Based on the information in https://github.com/sandeepmistry/noble/issues/560, subscriptions should be "data" instead of "read". This now works with noble 1.8.